### PR TITLE
Update DOCKER_VERSION arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.19
 LABEL maintainer="Matt Titmus <matthew.titmus@gmail.com>"
 LABEL date="2024-02-19"
 
-ARG DOCKER_VERSION=1.13.0
+ARG DOCKER_VERSION=1.12.0
 
 # We get curl so that we can avoid a separate ADD to fetch the Docker binary, and then we'll remove it.
 # Blatantly "borrowed" from Spotify's spotify/docker-gc image. Thanks, folks!

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.19
 LABEL maintainer="Matt Titmus <matthew.titmus@gmail.com>"
 LABEL date="2024-02-19"
 
-ARG DOCKER_VERSION=1.13.1
+ARG DOCKER_VERSION=1.13.0
 
 # We get curl so that we can avoid a separate ADD to fetch the Docker binary, and then we'll remove it.
 # Blatantly "borrowed" from Spotify's spotify/docker-gc image. Thanks, folks!

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.19
 LABEL maintainer="Matt Titmus <matthew.titmus@gmail.com>"
 LABEL date="2024-02-19"
 
-ARG DOCKER_VERSION=1.11.1
+ARG DOCKER_VERSION=1.13.1
 
 # We get curl so that we can avoid a separate ADD to fetch the Docker binary, and then we'll remove it.
 # Blatantly "borrowed" from Spotify's spotify/docker-gc image. Thanks, folks!


### PR DESCRIPTION
Updates `DOCKER_VERSION` to `1.12.0`, the oldest server version that supports the minimum API version supported by the current Docker release (v26), which is API v1.24.

Tested with local build with these Docker specs:

```
Client: Docker Engine - Community
 Version:           26.0.0
 API version:       1.45
 Go version:        go1.21.8
 Git commit:        2ae903e
 Built:             Wed Mar 20 15:18:01 2024
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          26.0.0
  API version:      1.45 (minimum version 1.24)
  Go version:       go1.21.8
  Git commit:       8b79278
  Built:            Wed Mar 20 15:18:01 2024
  OS/Arch:          linux/amd64
  Experimental:     false
```

Fixes #6. A better long-term solution probably includes moving this to an environment variable so it can be set in `docker-compose.yml` for runtime.