### PR TITLE
multi-platform build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,25 @@
 FROM alpine:3.19
 
 LABEL maintainer="Matt Titmus <matthew.titmus@gmail.com>"
-LABEL date="2024-02-19"
+LABEL date="2025-02-01"
 
-ARG DOCKER_VERSION=1.12.0
+ARG DOCKER_VERSION=27.5.1
+ARG TARGETARCH
 
 # We get curl so that we can avoid a separate ADD to fetch the Docker binary, and then we'll remove it.
 # Blatantly "borrowed" from Spotify's spotify/docker-gc image. Thanks, folks!
+# Map Docker's architecture for multi-platform build
 RUN apk --update add bash curl tzdata \
+  && case "${TARGETARCH}" in \
+         "amd64") ARCH="x86_64" ;; \
+         "arm64") ARCH="aarch64" ;; \
+         "arm") ARCH="armhf" ;; \
+         *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+     esac \
+  && echo "Resolved ARCH: ${ARCH}" \
+  && echo "Download URL: https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz" \
   && cd /tmp/ \
-  && curl -sSL -O https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz \
+  && curl -fSL -O https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz \
   && tar zxf docker-${DOCKER_VERSION}.tgz \
   && mkdir -p /usr/local/bin/ \
   && mv /tmp/docker/docker /usr/local/bin/ \


### PR DESCRIPTION
- upped docker version
- logic for docker arch mapping - multiplatform builds
- build with:  docker buildx build --platform "linux/amd64,linux/arm64" -t clockworksoul/docker-gc-cron:latest --push .